### PR TITLE
Revert "module: Add this project as Zephyr module with a board root"

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,4 +1,0 @@
-build:
-  settings:
-    board_root: .
-


### PR DESCRIPTION
Reverts OeySa/nRF9160-Hello_Board#1

Is not compatible with current tags.